### PR TITLE
Change package name to messagecloud/gateway-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following README assumes that you are using the following PHP extensions:
 Using [Composer](https://getcomposer.org/) you can easily download and build the app:
 
 ```bash
-$ composer require messagecloud/gateway
+$ composer require messagecloud/gateway-php
 ```
 
 ### Importing the Library

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "messagecloud/gateway",
+	"name": "messagecloud/gateway-php",
 	"description": "A PHP library to help you integrate the MessageCloud Gateway.",
 	"keywords": ["sms", "mobile", "billing", "phone", "cell", "text"],
 	"homepage": "http://www.messagecloud.com",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e494d1d72457c021a255a674a0e885fa",
+    "content-hash": "6acc6ce17142c2f6881f9f0c0aa78438",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
Following a conversation with @marcoleary we decided the package should instead be called `messagecloud/gateway-php` to be consistent with the repository name.